### PR TITLE
fix: Adding check for ETimedOut connections with Linux error code

### DIFF
--- a/test/Microsoft.TdsLib.UnitTest/IO/Connection/Tcp/TcpConnectionTest.cs
+++ b/test/Microsoft.TdsLib.UnitTest/IO/Connection/Tcp/TcpConnectionTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.TdsLib.UnitTest.IO.Connection.Tcp
             });
             DateTime endTime = DateTime.Now;
 
-            bool isError = socketException.ErrorCode == ETimedOutErrorCode || socketException.ErrorCode == (int)SocketError.NetworkUnreachable || socketException.ErrorCode == (int)SocketError.TimedOut;
+            bool isError = (socketException.ErrorCode == ETimedOutErrorCode || socketException.ErrorCode == (int)SocketError.NetworkUnreachable || socketException.ErrorCode == (int)SocketError.TimedOut);
 
             Assert.True(isError);
             Assert.True(endTime - startTime < TimeSpan.FromSeconds(timeoutSeconds * 2));
@@ -57,6 +57,7 @@ namespace Microsoft.TdsLib.UnitTest.IO.Connection.Tcp
             DateTime endTime = DateTime.Now;
 
             bool isError = (socketException.ErrorCode == ETimedOutErrorCode || socketException.ErrorCode == (int)SocketError.NetworkUnreachable || socketException.ErrorCode == (int)SocketError.TimedOut);
+            
             Assert.True(isError);
         }
 


### PR DESCRIPTION
The TcpConnectionTests were failing on Linux due to the Assert check only being relevant to Windows socket exceptions. This change adds an additional check for the ETimedOut error code of 110.